### PR TITLE
Fix FAISS initialization when no index exists

### DIFF
--- a/rag/faiss_store.py
+++ b/rag/faiss_store.py
@@ -21,7 +21,11 @@ class FaissStore:
             )
         else:
             print("📄 No existing FAISS index found — starting fresh.")
-            self.index = None
+            os.makedirs(self.persist_dir, exist_ok=True)
+            # Create an empty FAISS index so other components can interact
+            # without raising AttributeError when no documents have been
+            # ingested yet.
+            self.index = FAISS.from_texts([], embedding=self.embed_model)
 
     def add_documents(self, docs_with_metadata):
         """


### PR DESCRIPTION
## Summary
- avoid AttributeError when searching before ingesting
- initialize an empty FAISS index on first run

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f59a5744c8322ac079a0df8659f0a