### PR TITLE
Clean RAG index before ingest

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Built using LangChain, Ollama, and FAISS vector storage.
 - Parallel ingestion for faster pulls from SAM.gov
 - Automatically initializes the FAISS index if none exists
 - Posted dates displayed in search and RAG results
+- Cleans old vector data so only active solicitations remain
 
 
 ## Requirements
@@ -60,7 +61,8 @@ from rag.faiss_store import FaissStore
 store = FaissStore()
 ```
 
-Then run the ingest mode to populate it:
+Then run the ingest mode to populate it. Each run now clears any existing
+documents so only active solicitations remain:
 
 ```bash
 pipenv run python main.py --mode ingest
@@ -75,7 +77,7 @@ ingest mode.
 The CLI is modular — you can **ingest**, **search**, **rerank** or use a simple
 **RAG** mode independently:
 
-### 1. Ingest Opportunities
+### 1. Ingest Opportunities (clears old entries)
 
 ```bash
 pipenv run python main.py --mode ingest

--- a/agents/solicitation_agent.py
+++ b/agents/solicitation_agent.py
@@ -27,5 +27,5 @@ class SolicitationAgent:
             return
 
         print("🧠 Embedding and storing in FAISS...")
-        self.store.add_documents(processed_docs)
-        print("✅ Stored documents in FAISS.")
+        self.store.overwrite_documents(processed_docs)
+        print("✅ Stored active solicitations in FAISS.")

--- a/rag/faiss_store.py
+++ b/rag/faiss_store.py
@@ -48,3 +48,16 @@ class FaissStore:
 
         print(f"💾 Saving FAISS index to '{self.persist_dir}'")
         self.index.save_local(self.persist_dir)
+
+    def overwrite_documents(self, docs_with_metadata):
+        """Replace the existing FAISS index with new documents."""
+        print(f"🧹 Clearing old index and storing {len(docs_with_metadata)} active documents...")
+
+        texts = [doc['text'] for doc in docs_with_metadata]
+        metadatas = [doc['metadata'] for doc in docs_with_metadata]
+
+        os.makedirs(self.persist_dir, exist_ok=True)
+        self.index = FAISS.from_texts(texts, embedding=self.embed_model, metadatas=metadatas)
+
+        print(f"💾 Saving FAISS index to '{self.persist_dir}'")
+        self.index.save_local(self.persist_dir)

--- a/tasks/preprocess_task.py
+++ b/tasks/preprocess_task.py
@@ -5,6 +5,21 @@ class PreprocessTask(BaseTask):
         processed_docs = []
 
         for opp in opportunities:
+            # Skip inactive or archived opportunities when possible
+            archive_date = opp.get("archiveDate")
+            if archive_date:
+                try:
+                    from datetime import datetime
+
+                    ad = datetime.strptime(archive_date, "%m/%d/%Y")
+                    if ad < datetime.now():
+                        continue
+                except Exception:
+                    pass
+
+            if opp.get("active") is False:
+                continue
+
             description = opp.get("description") or ""
             title = opp.get("title", "Untitled")
             solicitation_number = opp.get("solicitationNumber", "Unknown")


### PR DESCRIPTION
## Summary
- purge existing embeddings during ingest so only active opportunities are stored
- skip archived/inactive opportunities in preprocessing
- add FAISS `overwrite_documents` helper
- document the new cleaning behaviour in README

## Testing
- `pipenv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fa44e5a9c83229346098416d9c00f