### PR TITLE
Improve RAG filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Built using LangChain, Ollama, and FAISS vector storage.
 - Modular architecture: ingestion chain, search chain, rerank chain
 - CLI interface for flexible operation (`ingest`, `search`, `rerank`)
 - Retrieval-Augmented Generation (RAG) mode for conversational answers
-- Set-aside filtering and top-N result limiting
+- Set-aside and NAICS code filtering with top-N result limiting
 - Parallel ingestion for faster pulls from SAM.gov
 - Automatically initializes the FAISS index if none exists
 - Posted dates displayed in search and RAG results
@@ -87,6 +87,8 @@ pipenv run python main.py --mode ingest
 
 ```bash
 pipenv run python main.py --mode search --query "AI contracting work for a small business"
+# Filter by set-aside or NAICS codes
+pipenv run python main.py --mode search --query "AI contracting" --setaside "8(a) Set-Aside" --naics "541511,541512"
 ```
 
 ### 3. Rerank with LLM Intelligence
@@ -147,6 +149,7 @@ pipenv run pytest -q
 pipenv run python main.py --mode ingest
 pipenv run python main.py --mode search --query "Cybersecurity support for government agencies"
 pipenv run python main.py --mode rerank --query "Cybersecurity support for government agencies"
+pipenv run python main.py --mode rag --query "Cybersecurity" --naics "541519" --setaside "Total Small Business Set-Aside (FAR 19.5)"
 pipenv run python solicitation_overview.py 02aa3325308f491d959ba968898accd6
 ```
 

--- a/llm/llama_rag_wrapper.py
+++ b/llm/llama_rag_wrapper.py
@@ -14,20 +14,26 @@ class LlamaRAG:
         )
         self.prompt_template = load_prompt("rag_prompt.txt")
 
-    def retrieve_docs(self, query, k=10, setasides=None):
-        """Retrieve documents matching the query and optional set-aside filter."""
+    def retrieve_docs(self, query, k=10, setasides=None, naics_codes=None):
+        """Retrieve documents matching the query with optional filters."""
         docs = self.vectorstore.similarity_search(query, k=k * 2)
+
         if setasides:
-            allowed = {sa.lower() for sa in setasides}
-            docs = [d for d in docs if d.metadata.get("setaside", "").lower() in allowed]
+            allowed_setaside = {sa.lower() for sa in setasides}
+            docs = [d for d in docs if d.metadata.get("setaside", "").lower() in allowed_setaside]
+
+        if naics_codes:
+            allowed_naics = {code.strip() for code in naics_codes}
+            docs = [d for d in docs if d.metadata.get("naics") in allowed_naics]
+
         return docs[:k]
 
-    def retrieve_context(self, query, k=10, setasides=None):
-        docs = self.retrieve_docs(query, k=k, setasides=setasides)
+    def retrieve_context(self, query, k=10, setasides=None, naics_codes=None):
+        docs = self.retrieve_docs(query, k=k, setasides=setasides, naics_codes=naics_codes)
         return "\n\n".join([doc.page_content for doc in docs]), docs
 
-    def generate_response(self, query, k=10, setasides=None):
-        context, _ = self.retrieve_context(query, k=k, setasides=setasides)
+    def generate_response(self, query, k=10, setasides=None, naics_codes=None):
+        context, _ = self.retrieve_context(query, k=k, setasides=setasides, naics_codes=naics_codes)
         prompt = self.prompt_template.format(query=query, context=context)
 
         completion = self.llm_client.chat.completions.create(

--- a/prompts/rag_prompt.txt
+++ b/prompts/rag_prompt.txt
@@ -1,0 +1,9 @@
+You are a helpful assistant that summarizes federal contracting opportunities.
+Use the provided context to answer the user's question and highlight the most relevant solicitations.
+
+Context:
+{context}
+
+User Query: {query}
+
+Answer:

--- a/prompts/rerank_prompt.txt
+++ b/prompts/rerank_prompt.txt
@@ -1,0 +1,8 @@
+You are an expert contracting advisor. Based on the user's query and the list of documents, rank the opportunities that best fit.
+
+Query: {query}
+
+Documents:
+{documents}
+
+Top Opportunities:


### PR DESCRIPTION
## Summary
- add NAICS filtering to search and RAG modes
- expose `--naics` option on CLI
- include prompt templates in repo
- document new filter capability in README

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_683fa70813e88322a7950616f726e93d