### PR TITLE
Fix empty RAG response handling

### DIFF
--- a/llm/llama_rag_wrapper.py
+++ b/llm/llama_rag_wrapper.py
@@ -49,6 +49,12 @@ class LlamaRAG:
 
     def generate_response(self, query, k=10, setasides=None, naics_codes=None):
         context, _ = self.retrieve_context(query, k=k, setasides=setasides, naics_codes=naics_codes)
+
+        if not context.strip():
+            # Avoid sending an empty context to the LLM which would result in
+            # hallucinated answers.
+            return "No relevant opportunities were found in the vector store."
+
         prompt = self.prompt_template.format(query=query, context=context)
 
         completion = self.llm_client.chat.completions.create(

--- a/main.py
+++ b/main.py
@@ -45,6 +45,10 @@ def run_rag(query, api_key, setasides=None, naics_codes=None, k=20):
         print(f"Set-Aside: {meta.get('setaside')}")
         print()
 
+    if not docs:
+        print("⚠️ No matching solicitations found. Try running the ingest command first.")
+        return
+
     response = rag.generate_response(query, k=k, setasides=setasides, naics_codes=naics_codes)
     print("\n📄 RAG-Enhanced Response:\n")
     print(response)


### PR DESCRIPTION
## Summary
- avoid hallucinated answers when the vector store returns no matches
- alert users to ingest data before running RAG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684055f42a448322bd2ba81883269a01