### PR TITLE
Add downloader for solicitation details and attachments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ prompts/*.txt
 index.faiss
 index.pkl
 *__pycache__/
+raw_data*

--- a/Pipfile
+++ b/Pipfile
@@ -13,6 +13,7 @@ langchain-ollama = "*"
 bs4 = "*"
 boto3 = "*"
 llama-api-client = "*"
+pytest = "*"
 
 [dev-packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "5aabc805f834c9a989189751260bddd2444063d5c2b877a643df27432b95f112"
+            "sha256": "1f07be64f3d49c7c86525c169f08fc149b590cd260bf2e826199ad7c30d820a0"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -486,6 +486,14 @@
             "markers": "python_version >= '3.6'",
             "version": "==3.10"
         },
+        "iniconfig": {
+            "hashes": [
+                "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7",
+                "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==2.1.0"
+        },
         "jmespath": {
             "hashes": [
                 "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980",
@@ -847,6 +855,14 @@
             "markers": "python_version >= '3.8'",
             "version": "==24.2"
         },
+        "pluggy": {
+            "hashes": [
+                "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3",
+                "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==1.6.0"
+        },
         "propcache": {
             "hashes": [
                 "sha256:035e631be25d6975ed87ab23153db6a73426a48db688070d925aa27e996fe93c",
@@ -1071,6 +1087,23 @@
             ],
             "markers": "python_version >= '3.9'",
             "version": "==2.9.1"
+        },
+        "pygments": {
+            "hashes": [
+                "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f",
+                "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==2.19.1"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:14d920b48472ea0dbf68e45b96cd1ffda4705f33307dcc86c676c1b5104838a6",
+                "sha256:f40f825768ad76c0977cbacdf1fd37c6f7a468e460ea6a0636078f8972d4517e"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.9'",
+            "version": "==8.4.0"
         },
         "python-dateutil": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -122,6 +122,12 @@ Process the entire bucket at once:
 pipenv run python main.py --mode enrich --all
 ```
 
+Process only a single day's records:
+
+```bash
+pipenv run python main.py --mode enrich --date 2025-06-17
+```
+
 ### 6. Solicitation Overview
 
 Summarize a single solicitation by its notice ID:

--- a/README.md
+++ b/README.md
@@ -108,7 +108,21 @@ Use a lightweight Retrieval-Augmented Generation mode. Requires `LLAMA_API_KEY`.
 pipenv run python main.py --mode rag --query "Explain AI contract opportunities in cyber"
 ```
 
-### 5. Solicitation Overview
+### 5. Enrich Stored Records
+
+Download long descriptions and all attachment files for a saved JSON record in MinIO.
+
+```bash
+pipenv run python main.py --mode enrich --path sam-archive/2025/06/17/<notice_id>.json
+```
+
+Process the entire bucket at once:
+
+```bash
+pipenv run python main.py --mode enrich --all
+```
+
+### 6. Solicitation Overview
 
 Summarize a single solicitation by its notice ID:
 

--- a/fetch_minio_details.py
+++ b/fetch_minio_details.py
@@ -1,0 +1,43 @@
+import argparse
+import json
+import boto3
+
+from utils.env_loader import load_env
+from utils.solicitation_assets import enrich_record_with_details
+
+
+def main(key: str):
+    config = load_env()
+    s3 = boto3.client(
+        "s3",
+        endpoint_url="http://localhost:9000",
+        aws_access_key_id=config.get("MINIO_ACCESS_KEY"),
+        aws_secret_access_key=config.get("MINIO_SECRET_KEY"),
+        region_name="us-east-1",
+    )
+    bucket = "sam-archive"
+    obj = s3.get_object(Bucket=bucket, Key=key)
+    record = json.loads(obj["Body"].read())
+
+    enriched = enrich_record_with_details(
+        record, s3, bucket, api_key=config.get("SAM_API_KEY"), dry_run=False
+    )
+
+    print(json.dumps(
+        {
+            "description_key": enriched.get("description_data_key"),
+            "attachment_keys": enriched.get("attachment_keys", []),
+        },
+        indent=2,
+    ))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Fetch description and attachments for a saved SAM notice"
+    )
+    parser.add_argument(
+        "key", help="S3 key for the JSON file, e.g. 2025/06/16/<notice_id>.json"
+    )
+    args = parser.parse_args()
+    main(args.key)

--- a/fetch_minio_details.py
+++ b/fetch_minio_details.py
@@ -3,10 +3,10 @@ import json
 import boto3
 
 from utils.env_loader import load_env
-from utils.solicitation_assets import enrich_record_with_details
+from utils.solicitation_assets import enrich_record_with_details, parse_s3_path
 
 
-def main(key: str):
+def main(path: str):
     config = load_env()
     s3 = boto3.client(
         "s3",
@@ -15,7 +15,7 @@ def main(key: str):
         aws_secret_access_key=config.get("MINIO_SECRET_KEY"),
         region_name="us-east-1",
     )
-    bucket = "sam-archive"
+    bucket, key = parse_s3_path(path)
     obj = s3.get_object(Bucket=bucket, Key=key)
     record = json.loads(obj["Body"].read())
 
@@ -37,7 +37,10 @@ if __name__ == "__main__":
         description="Fetch description and attachments for a saved SAM notice"
     )
     parser.add_argument(
-        "key", help="S3 key for the JSON file, e.g. 2025/06/16/<notice_id>.json"
+        "path",
+        help=(
+            "S3 path to the JSON file, e.g. sam-archive/2025/06/16/<notice_id>.json"
+        ),
     )
     args = parser.parse_args()
-    main(args.key)
+    main(args.path)

--- a/main.py
+++ b/main.py
@@ -80,6 +80,11 @@ def main():
         help="Enrich every JSON record in the specified bucket",
     )
     parser.add_argument(
+        "--date",
+        type=str,
+        help="Process only records from this date (YYYY-MM-DD)",
+    )
+    parser.add_argument(
         "--bucket",
         type=str,
         default="sam-archive",
@@ -139,8 +144,8 @@ def main():
         import json
         import boto3
 
-        if not args.path and not args.all:
-            print("❌ --path or --all is required for enrich mode.")
+        if not args.path and not args.all and not args.date:
+            print("❌ --path, --date, or --all is required for enrich mode.")
             return
 
         s3 = boto3.client(
@@ -172,6 +177,12 @@ def main():
                     if not key.endswith(".json"):
                         continue
                     process_record(bucket, key)
+        elif args.date:
+            bucket = args.bucket
+            from utils.solicitation_assets import list_json_keys_for_date
+
+            for key in list_json_keys_for_date(s3, bucket, args.date):
+                process_record(bucket, key)
         else:
             bucket, key = parse_s3_path(args.path, args.bucket)
             process_record(bucket, key)

--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 import argparse
 from utils.env_loader import load_env
+from utils.solicitation_assets import enrich_record_with_details, parse_s3_path
 from agents.solicitation_agent import SolicitationAgent
 from chains.semantic_search_chain import SemanticSearchChain
 from chains.rerank_chain import RerankChain
@@ -51,7 +52,12 @@ def run_rag(query, api_key, setasides=None, naics_codes=None, k=20):
 
 def main():
     parser = argparse.ArgumentParser(description="SAM Solicitation Agent CLI")
-    parser.add_argument("--mode", choices=["ingest", "search", "rerank", "rag"], required=True, help="Mode to run")
+    parser.add_argument(
+        "--mode",
+        choices=["ingest", "search", "rerank", "rag", "enrich"],
+        required=True,
+        help="Mode to run",
+    )
     parser.add_argument("--query", type=str, help="Search query (required for search/rerank/rag)")
     parser.add_argument(
         "--setaside",
@@ -62,6 +68,22 @@ def main():
         "--naics",
         type=str,
         help="Comma-separated list of NAICS codes to filter results",
+    )
+    parser.add_argument(
+        "--path",
+        type=str,
+        help="S3 path for a single record, e.g. sam-archive/2025/06/16/<id>.json",
+    )
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Enrich every JSON record in the specified bucket",
+    )
+    parser.add_argument(
+        "--bucket",
+        type=str,
+        default="sam-archive",
+        help="Bucket to use with --all or when --path lacks a bucket",
     )
 
     args = parser.parse_args()
@@ -112,6 +134,47 @@ def main():
             naics_codes=naics_list,
             k=20,
         )
+
+    elif args.mode == "enrich":
+        import json
+        import boto3
+
+        if not args.path and not args.all:
+            print("❌ --path or --all is required for enrich mode.")
+            return
+
+        s3 = boto3.client(
+            "s3",
+            endpoint_url="http://localhost:9000",
+            aws_access_key_id=config.get("MINIO_ACCESS_KEY"),
+            aws_secret_access_key=config.get("MINIO_SECRET_KEY"),
+            region_name="us-east-1",
+        )
+
+        api_key = config.get("SAM_API_KEY")
+
+        def process_record(bucket: str, key: str) -> None:
+            obj = s3.get_object(Bucket=bucket, Key=key)
+            record = json.loads(obj["Body"].read())
+            enriched = enrich_record_with_details(record, s3, bucket, api_key=api_key)
+            print(json.dumps({
+                "noticeId": record.get("noticeId"),
+                "description_key": enriched.get("description_data_key"),
+                "attachment_keys": enriched.get("attachment_keys", []),
+            }, indent=2))
+
+        if args.all:
+            bucket = args.bucket
+            paginator = s3.get_paginator("list_objects_v2")
+            for page in paginator.paginate(Bucket=bucket):
+                for obj in page.get("Contents", []):
+                    key = obj["Key"]
+                    if not key.endswith(".json"):
+                        continue
+                    process_record(bucket, key)
+        else:
+            bucket, key = parse_s3_path(args.path, args.bucket)
+            process_record(bucket, key)
 
 if __name__ == "__main__":
     main()

--- a/tests/test_solicitation_assets.py
+++ b/tests/test_solicitation_assets.py
@@ -1,0 +1,54 @@
+import json
+from utils.solicitation_assets import enrich_record_with_details
+
+
+class DummyS3:
+    def __init__(self):
+        self.objects = {}
+
+    def put_object(self, Bucket, Key, Body):
+        self.objects[(Bucket, Key)] = Body
+
+
+def test_enrich_record_with_details(monkeypatch):
+    record = {
+        "noticeId": "abc123",
+        "postedDate": "2025-06-16",
+        "description": "http://example.com/desc",
+        "resourceLinks": [
+            "http://example.com/file1/download",
+            "http://example.com/file2/download",
+        ],
+    }
+
+    class DummyResp:
+        def __init__(self, content, json_data=None):
+            self.content = content
+            self._json = json_data
+            self.headers = {}
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            if self._json is None:
+                raise ValueError()
+            return self._json
+
+    calls = []
+
+    def mock_get(url):
+        calls.append(url)
+        if url == "http://example.com/desc":
+            return DummyResp(b"{}", json_data={"description": "full text"})
+        return DummyResp(b"data")
+
+    monkeypatch.setattr("requests.get", mock_get)
+
+    s3 = DummyS3()
+    enriched = enrich_record_with_details(record, s3, "bucket", dry_run=False)
+
+    assert enriched["description_data_key"].endswith("description.json")
+    assert len(enriched["attachment_keys"]) == 2
+    assert len(s3.objects) == 3
+    assert calls[0] == "http://example.com/desc"

--- a/tests/test_solicitation_assets.py
+++ b/tests/test_solicitation_assets.py
@@ -1,5 +1,5 @@
 import json
-from utils.solicitation_assets import enrich_record_with_details
+from utils.solicitation_assets import enrich_record_with_details, parse_s3_path
 
 
 class DummyS3:
@@ -52,3 +52,13 @@ def test_enrich_record_with_details(monkeypatch):
     assert len(enriched["attachment_keys"]) == 2
     assert len(s3.objects) == 3
     assert calls[0] == "http://example.com/desc"
+
+
+def test_parse_s3_path():
+    b, k = parse_s3_path("sam-archive/2025/06/16/foo.json")
+    assert b == "sam-archive"
+    assert k == "2025/06/16/foo.json"
+
+    b, k = parse_s3_path("2025/06/16/foo.json", "sam-archive")
+    assert b == "sam-archive"
+    assert k == "2025/06/16/foo.json"

--- a/utils/solicitation_assets.py
+++ b/utils/solicitation_assets.py
@@ -45,6 +45,16 @@ def enrich_record_with_details(
     key_prefix = dt.strftime("%Y/%m/%d")
     base_prefix = f"{key_prefix}/{notice_id}"
 
+    # Skip enrichment if this notice already has a folder of assets
+    if not dry_run:
+        existing = s3_client.list_objects_v2(
+            Bucket=bucket,
+            Prefix=f"{base_prefix}/",
+            MaxKeys=1,
+        )
+        if existing.get("KeyCount", 0) > 0:
+            return record
+
     # ------------------------------------------------------------------
     desc = record.get("description")
     if isinstance(desc, str) and desc.startswith("http"):

--- a/utils/solicitation_assets.py
+++ b/utils/solicitation_assets.py
@@ -2,7 +2,7 @@ import os
 import json
 import re
 import requests
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
 
 def enrich_record_with_details(
@@ -95,3 +95,27 @@ def enrich_record_with_details(
         record["attachment_keys"] = attachment_keys
 
     return record
+
+
+def parse_s3_path(path: str, default_bucket: str = "sam-archive") -> Tuple[str, str]:
+    """Split an S3 path into bucket and key.
+
+    Parameters
+    ----------
+    path : str
+        Either ``<bucket>/<key>`` or just ``<key>``.  If only a key is
+        provided, ``default_bucket`` is returned as the bucket name.
+
+    Returns
+    -------
+    Tuple[str, str]
+        The bucket and key values.
+    """
+    if "/" not in path:
+        return default_bucket, path
+
+    first, rest = path.split("/", 1)
+    if first.isdigit():
+        # Looks like a year prefix rather than a bucket name
+        return default_bucket, path
+    return first, rest

--- a/utils/solicitation_assets.py
+++ b/utils/solicitation_assets.py
@@ -1,0 +1,97 @@
+import os
+import json
+import re
+import requests
+from typing import Dict, List, Optional
+
+
+def enrich_record_with_details(
+    record: Dict,
+    s3_client,
+    bucket: str,
+    *,
+    api_key: Optional[str] = None,
+    endpoint_url: str = "http://localhost:9000",
+    dry_run: bool = False,
+) -> Dict:
+    """Fetch full description and attachments for a solicitation record.
+
+    If ``record['description']`` is a URL it is fetched and the resulting JSON
+    or text is stored in the same S3 prefix as the original record under
+    ``<prefix>/<notice_id>/description.json``.
+
+    Any URLs in ``record['resourceLinks']`` are downloaded and uploaded to the
+    bucket under ``<prefix>/<notice_id>/``. The resulting S3 keys are stored
+    in ``record['attachment_keys']``.
+    """
+    notice_id = record.get("noticeId")
+    posted = record.get("postedDate")
+    if not notice_id or not posted:
+        return record
+
+    # Compute base prefix (same logic as ArchiveSolicitationsTask)
+    try:
+        from datetime import datetime
+
+        dt = datetime.fromisoformat(posted.replace("Z", "+00:00"))
+    except Exception:
+        try:
+            from datetime import datetime
+
+            dt = datetime.strptime(posted, "%m/%d/%Y")
+        except Exception:
+            return record
+
+    key_prefix = dt.strftime("%Y/%m/%d")
+    base_prefix = f"{key_prefix}/{notice_id}"
+
+    # ------------------------------------------------------------------
+    desc = record.get("description")
+    if isinstance(desc, str) and desc.startswith("http"):
+        url = desc
+        if api_key and "api_key=" not in url:
+            sep = "&" if "?" in url else "?"
+            url = f"{url}{sep}api_key={api_key}"
+        try:
+            resp = requests.get(url)
+            resp.raise_for_status()
+            try:
+                desc_data = resp.json()
+            except ValueError:
+                desc_data = {"description": resp.text}
+            if not dry_run:
+                key = f"{base_prefix}/description.json"
+                body = json.dumps(desc_data).encode("utf-8")
+                s3_client.put_object(Bucket=bucket, Key=key, Body=body)
+                record["description_data_key"] = key
+            else:
+                record["description_data"] = desc_data
+        except Exception as e:
+            print(f"⚠️ Failed to fetch description for {notice_id}: {e}")
+
+    # ------------------------------------------------------------------
+    attachment_keys: List[str] = []
+    for link in record.get("resourceLinks", []):
+        if not isinstance(link, str) or not link.startswith("http"):
+            continue
+        try:
+            resp = requests.get(link)
+            resp.raise_for_status()
+            file_id = link.rstrip("/").split("/")[-2]
+            filename = file_id
+            cd = resp.headers.get("Content-Disposition")
+            if cd:
+                m = re.search(r"filename=\"?([^\";]+)\"?", cd)
+                if m:
+                    filename = m.group(1)
+            key = f"{base_prefix}/{filename}"
+            if not dry_run:
+                s3_client.put_object(Bucket=bucket, Key=key, Body=resp.content)
+            attachment_keys.append(key)
+        except Exception as e:
+            print(f"⚠️ Failed to download attachment {link}: {e}")
+
+    if attachment_keys:
+        record["attachment_keys"] = attachment_keys
+
+    return record

--- a/utils/solicitation_assets.py
+++ b/utils/solicitation_assets.py
@@ -71,7 +71,8 @@ def enrich_record_with_details(
 
     # ------------------------------------------------------------------
     attachment_keys: List[str] = []
-    for link in record.get("resourceLinks", []):
+    links = record.get("resourceLinks") or []
+    for link in links:
         if not isinstance(link, str) or not link.startswith("http"):
             continue
         try:


### PR DESCRIPTION
## Summary
- add helper `enrich_record_with_details` to download long description and attachment files
- add script `fetch_minio_details.py` to fetch and enrich a stored record
- test new helper with mocked requests

## Testing
- `pipenv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850a6efe3448322b14944fb84e3a089